### PR TITLE
Update cf push to generate a random route

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Open the "specs.html" file in a browser to begin.
 
 You can find Jasmine documentation [here](http://jasmine.github.io/2.0/introduction.html). 
 
-You can push these files to PWS easily, with `cf push YOUR_APP_NAME -m 64M`.
+You can push these files to PWS easily, with `cf push YOUR_APP_NAME -m 64M --random-route`.
 
 You can sign up for a free trial PWS account at http://run.pivotal.io/
 


### PR DESCRIPTION
If an app name is not globally unique, then the push will fail when trying to create a route. This leads to a bit of unnecessary frustration, since this is an opaque feature of Cloud Foundry.